### PR TITLE
Fixing predicate bug in worker_thread_t

### DIFF
--- a/src/common/worker_thread.cpp
+++ b/src/common/worker_thread.cpp
@@ -33,7 +33,7 @@ void worker_thread_t::wakeup(bool wait)
 
     if (wait) {
         // Wait for worker to finish one round
-        wait_for_round(this_round + 1);
+        wait_for_round(this_round);
     }
 }
 


### PR DESCRIPTION
Assume that there is a single thread (T1) calling wakeup() to a worker thread
(TW). The worker thread is only awake externally, not proactivelly.

TW starts waiting in the condition variable to be awaken.
T1 calls wakeup(wait=true). No round was executed so far, so
rounds_completed == 0.
T1 sets this_round = 1 (rounds_completed+1). This means that the round assigned
to T1 is 1.
TW is not busy, so this_round is NOT incremented.
At the end of wakeup(), T1 calls wait_for_round(2), i.e., this_round+1.

This does not make any sense, T1 has to call wait_for_round(1). Otherwise the
predicate will never be evaluated and T1 is going to wait forever or until
the worker is activated again by some reason.
