### PR TITLE
Moving #defines to proper file

### DIFF
--- a/config/shore.def
+++ b/config/shore.def
@@ -59,3 +59,26 @@
    in the log with time
 */
 #define TIMED_LOG_RECORDS
+
+/*
+ * We found that pure spinning is much faster than mutex sleep/wake-up as in [JUNG13].
+ * As far as we don't over-subscribe workers, this has no disadvantages.
+ * Pure spinning means we don't have to do anything in lock release, we don't have to do
+ * keep any of mutexes, so much faster.
+ * \ingroup RAWLOCK
+ */
+#define PURE_SPIN_RAWLOCK
+
+/* A flag whether the bufferpool should alternate location of latches and control blocks
+ * starting at an odd multiple of 64B as follows: |CB0|L0|L1|CB1|CB2|L2|L3|CB3|...
+ * This layout addresses a pathology that we attribute to the hardware spatial prefetcher.
+ * The default layout allocates a latch right after a control block so that
+ * the control block and latch live in adjacent cache lines (in the same 128B sector).
+ * The pathology happens because when we write-access the latch, the processor prefetches
+ * the control block in read-exclusive mode even if we late really only read-access the
+ * control block. This causes unnecessary coherence traffic. With the new layout, we avoid
+ * having a control block and latch in the same 128B sector.
+ */
+#define BP_ALTERNATE_CB_LATCH
+
+#define USE_TLS_ALLOCATOR

--- a/config/shore.def
+++ b/config/shore.def
@@ -69,16 +69,4 @@
  */
 #define PURE_SPIN_RAWLOCK
 
-/* A flag whether the bufferpool should alternate location of latches and control blocks
- * starting at an odd multiple of 64B as follows: |CB0|L0|L1|CB1|CB2|L2|L3|CB3|...
- * This layout addresses a pathology that we attribute to the hardware spatial prefetcher.
- * The default layout allocates a latch right after a control block so that
- * the control block and latch live in adjacent cache lines (in the same 128B sector).
- * The pathology happens because when we write-access the latch, the processor prefetches
- * the control block in read-exclusive mode even if we late really only read-access the
- * control block. This causes unnecessary coherence traffic. With the new layout, we avoid
- * having a control block and latch in the same 128B sector.
- */
-#define BP_ALTERNATE_CB_LATCH
-
 #define USE_TLS_ALLOCATOR

--- a/config/shore.def
+++ b/config/shore.def
@@ -68,5 +68,3 @@
  * \ingroup RAWLOCK
  */
 #define PURE_SPIN_RAWLOCK
-
-#define USE_TLS_ALLOCATOR

--- a/config/shore.def
+++ b/config/shore.def
@@ -46,13 +46,6 @@
  */
 #define EXPENSIVE_LATCH_COUNTS 0
 
-/* CS: Define this to keep the log files for later inspection or debug.
-   If set, partitions are cleaned normally, but the call to unlink is
-   skipped. Thus, the log manager should behave the exact same way, but
-   the files will be kept.
- */
-#define KEEP_LOG_PARTITIONS
-
 /* CS: IF this is set, then system event log records, as well as certain
    selected log records (e.g., restore events), will contain an additional
    field with a timestamp. This is useful in experiments to correlate events

--- a/config/shore.def
+++ b/config/shore.def
@@ -5,15 +5,6 @@
 #define HUGETLBFS_PATH "/mnt/huge/SSM-BUFPOOL"
 
 /*
- * Define this if you want to include crash test hooks in your
- * executable.  (For use with ssh, really).
- * A release executable should not be built with this unless you
- * are a maintainer and want to test it.
- */
-#undef USE_SSMTEST
-
-
-/*
  * Define these if you do not like the default lengths (in tid_t.h)
  */
 #undef COMMON_GTID_LENGTH

--- a/src/sm/bf_tree.h
+++ b/src/sm/bf_tree.h
@@ -47,25 +47,11 @@ const uint32_t SWIZZLED_PID_BIT = 0x80000000;
 // A flag whether the bufferpool can evict pages of btree inner nodes
 #define BP_CAN_EVICT_INNER_NODE
 
-// A flag whether the bufferpool should alternate location of latches and control blocks
-// starting at an odd multiple of 64B as follows: |CB0|L0|L1|CB1|CB2|L2|L3|CB3|...
-// This layout addresses a pathology that we attribute to the hardware spatial prefetcher.
-// The default layout allocates a latch right after a control block so that
-// the control block and latch live in adjacent cache lines (in the same 128B sector).
-// The pathology happens because when we write-access the latch, the processor prefetches
-// the control block in read-exclusive mode even if we late really only read-access the
-// control block. This causes unnecessary coherence traffic. With the new layout, we avoid
-// having a control block and latch in the same 128B sector.
-#define BP_ALTERNATE_CB_LATCH
-
 // A flag whether the bufferpool maintains a per-frame counter that tracks how many
 // swizzled pointers are in each frame. This counter is a conservative hint rather than
 // an accurate counter as the bufferpool does not track removals of pointers from a page
 // which can happen during merges.
 #define BP_TRACK_SWIZZLED_PTR_CNT
-
-// Use the new layout with swizzling
-#define BP_ALTERNATE_CB_LATCH
 
 /**
  * When unswizzling is triggered, _about_ this number of frames will be unswizzled at once.

--- a/src/sm/bf_tree.h
+++ b/src/sm/bf_tree.h
@@ -41,42 +41,11 @@ enum evict_urgency_t {
 /** a swizzled pointer (page ID) has this bit ON. */
 const uint32_t SWIZZLED_PID_BIT = 0x80000000;
 
-// A flag whether the bufferpool maintains replacement priority per page.
-#define BP_MAINTAIN_REPLACEMENT_PRIORITY
-
-// A flag whether the bufferpool can evict pages of btree inner nodes
-#define BP_CAN_EVICT_INNER_NODE
-
-// A flag whether the bufferpool maintains a per-frame counter that tracks how many
-// swizzled pointers are in each frame. This counter is a conservative hint rather than
-// an accurate counter as the bufferpool does not track removals of pointers from a page
-// which can happen during merges.
-#define BP_TRACK_SWIZZLED_PTR_CNT
-
-/**
- * When unswizzling is triggered, _about_ this number of frames will be unswizzled at once.
- * The smaller this number, the more frequent you need to trigger unswizzling.
- */
-const uint32_t UNSWIZZLE_BATCH_SIZE = 1000;
-
 /**
 * When eviction is triggered, _about_ this number of frames will be evicted at once.
 * Given as a ratio of the buffer size (currently 1%)
 */
 const float EVICT_BATCH_RATIO = 0.01;
-
-/**
-* We don't go through frames for each evict/unswizzle try.
-*/
-const uint16_t EVICT_MAX_ROUNDS = 20;
-
-class bf_eviction_thread_t : public smthread_t
-{
-public:
-    bf_eviction_thread_t();
-
-    virtual void run();
-};
 
 /**
  * \Brief The new buffer manager that exploits the tree structure of indexes.
@@ -100,7 +69,6 @@ class bf_tree_m {
     friend class test_bf_fixed; // for testcases
     friend class bf_tree_cleaner; // for page cleaning
     friend class bf_tree_cleaner_slave_thread_t; // for page cleaning
-    friend class bf_eviction_thread_t;
     friend class WarmupThread;
     friend class page_cleaner_decoupled;
 

--- a/src/sm/lock_raw.h
+++ b/src/sm/lock_raw.h
@@ -96,15 +96,6 @@
 #include "lsn.h"
 
 /**
- * We found that pure spinning is much faster than mutex sleep/wake-up as in [JUNG13].
- * As far as we don't over-subscribe workers, this has no disadvantages.
- * Pure spinning means we don't have to do anything in lock release, we don't have to do
- * keep any of mutexes, so much faster.
- * \ingroup RAWLOCK
- */
-#define PURE_SPIN_RAWLOCK
-
-/**
  * \brief Invokes "mfence", which is sfence + lfence.
  * \ingroup RAWLOCK
  * \details

--- a/src/sm/page_cleaner.cpp
+++ b/src/sm/page_cleaner.cpp
@@ -40,10 +40,17 @@ void page_cleaner_base::flush_workspace(size_t from, size_t to)
         // Assertion below may fail for decoupled cleaner, and it's OK
         // w_assert1(i == from || _workspace[i].pid == _workspace[i - 1].pid + 1);
 
+        rc_t rc = cb.latch().latch_acquire(LATCH_EX, sthread_t::WAIT_IMMEDIATE);
+        if (rc.is_error()) {
+            continue;   // Could not latch page in EX mode -- just skip it
+        }
+
         cb.pin();
         if (cb._pid == _workspace[i].pid && cb.get_clean_lsn() < _clean_lsn) {
             cb.set_clean_lsn(_clean_lsn);
         }
         cb.unpin();
+
+        cb.latch().latch_release();
     }
 }

--- a/src/sm/sm.cpp
+++ b/src/sm/sm.cpp
@@ -87,11 +87,7 @@ bool         smlevel_0::shutdown_clean = false;
 bool         smlevel_0::shutting_down = false;
 
 
-#ifdef USE_TLS_ALLOCATOR
-    sm_tls_allocator smlevel_0::allocator;
-#else
-    sm_naive_allocator smlevel_0::allocator;
-#endif
+sm_tls_allocator smlevel_0::allocator;
 
 memalign_allocator<char, smlevel_0::IO_ALIGN> smlevel_0::aligned_allocator;
 

--- a/src/sm/sm_base.h
+++ b/src/sm/sm_base.h
@@ -317,9 +317,6 @@ public:
 
     static ErrLog* errlog;
 
-    // TODO: allocator flag should be specified by cmake
-#define USE_TLS_ALLOCATOR
-
 #ifdef USE_TLS_ALLOCATOR
     static sm_tls_allocator allocator;
 #else

--- a/src/sm/sm_base.h
+++ b/src/sm/sm_base.h
@@ -317,11 +317,7 @@ public:
 
     static ErrLog* errlog;
 
-#ifdef USE_TLS_ALLOCATOR
     static sm_tls_allocator allocator;
-#else
-    static sm_naive_allocator allocator;
-#endif
 
     static constexpr size_t IO_ALIGN = 512;
     static memalign_allocator<char, IO_ALIGN> aligned_allocator;


### PR DESCRIPTION
Defining variable in the source files might generate unpredictable bugs if
dependency between compilation units change.

For example, #define BP_ALTERNATE_CB_LATCH was done in bf_tree.h, but used
also in bf_tree_cb.h. If someone else included bf_tree_cb.h without #define,
weird behaviors would happen.